### PR TITLE
BROKEN: Track maximum id

### DIFF
--- a/idmap/Cargo.toml
+++ b/idmap/Cargo.toml
@@ -24,6 +24,7 @@ fixedbitset = "0.5"
 # optional features
 serde = { version = "1", optional = true }
 petgraph = { version = "0.8", optional = true }
+rustversion = "1"
 
 [lints]
 workspace = true

--- a/idmap/src/direct.rs
+++ b/idmap/src/direct.rs
@@ -7,6 +7,7 @@ pub mod map;
 mod serde;
 pub mod set;
 
+use intid::IntegerId;
 pub use self::map::DirectIdMap;
 pub use self::set::DirectIdSet;
 use intid::uint::UnsignedPrimInt;
@@ -21,3 +22,17 @@ fn oom_id(id: impl UnsignedPrimInt) -> ! {
         intid::uint::debug_desc(id),
     )
 }
+
+/// Private trait used to
+trait IntegerIdExt: IntegerId {
+    /// Invokes [`Self::from_int_unchecked`] with a `usize` argument.
+    #[inline]
+    unsafe fn from_usize_unchecked(index: usize) -> Self {
+        Self::from_int_unchecked(intid::uint::from_usize_wrapping(index))
+    }
+    #[inline]
+    fn to_usize_checked(&self) -> Option<usize> {
+        intid::uint::to_usize_checked(self.to_int())
+    }
+}
+impl<K: IntegerId> IntegerIdExt for K {}


### PR DESCRIPTION
This was added in an attempt to give additional useful information,
and make reverse iteration practical by skipping padding.

This is unacceptable for performance reasons, due to the need for a potential `O(n)` scan through memory on remove.

## Future Optimization
The `RawVec` optimization/removing the `len` field still has potential!
This is just a lookup table and there is no inherent reason why `len != capacity`.
