### PR TITLE
Add iterator over IntegerIdContiguous

### DIFF
--- a/intid-core/src/trusted.rs
+++ b/intid-core/src/trusted.rs
@@ -67,3 +67,12 @@ impl<T: IntegerId> TrustedRangeToken<T> {
         }
     }
 }
+
+/*
+/// Indicates
+pub struct TrustedContiguousToken<T> {
+
+}
+impl<T: IntegerId> TrustedContiguousToken<T> {
+}
+*/

--- a/intid-core/src/uint.rs
+++ b/intid-core/src/uint.rs
@@ -5,6 +5,7 @@
 
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::Hash;
+use core::ops::{Add, Div, Mul, Sub};
 
 mod sealed;
 
@@ -56,7 +57,34 @@ pub trait UnsignedPrimInt:
     + MaybeNumTrait
     + MaybePod
     + MaybeContiguous
+    + Add<Output=Self>
+    + Sub<Output=Self>
+    + Mul<Output=Self>
+    + Div<Output=Self>
 {
+}
+
+/// Subtract the specified value from the integer,
+/// triggering UB if the subtraction overflows.
+///
+/// # Safety
+/// Undefined behavior if the subtraction overflows.
+#[inline]
+pub unsafe fn unchecked_sub<T: UnsignedPrimInt>(left: T, right: T) -> T {
+    // SAFETY: Delegates responsibility
+    unsafe { sealed::PrivateUnsignedInt::unchecked_sub(left, right) }
+}
+
+
+/// Add the specified values,
+/// triggering UB if the addition overflows.
+///
+/// # Safety
+/// Undefined behavior if the addition overflows.
+#[inline]
+pub unsafe fn unchecked_add<T: UnsignedPrimInt>(left: T, right: T) -> T {
+    // SAFETY: Delegates responsibility
+    unsafe { sealed::PrivateUnsignedInt::unchecked_add(left, right) }
 }
 
 /// Cast from one [`UnsignedPrimInt`] into another,

--- a/intid-core/src/uint/sealed.rs
+++ b/intid-core/src/uint/sealed.rs
@@ -7,6 +7,8 @@ pub trait PrivateUnsignedInt: Sized {
     const TYPE_NAME: &'static str;
     fn checked_add(self, other: Self) -> Option<Self>;
     fn checked_sub(self, other: Self) -> Option<Self>;
+    unsafe fn unchecked_add(self, other: Self) -> Self;
+    unsafe fn unchecked_sub(self, other: Self) -> Self;
     fn from_usize_checked(val: usize) -> Option<Self>;
     fn from_usize_wrapping(val: usize) -> Self;
     #[allow(clippy::wrong_self_convention)]
@@ -37,6 +39,16 @@ macro_rules! impl_primint {
             #[inline]
             fn checked_sub(self, other: Self) -> Option<Self> {
                 <$target>::checked_sub(self, other)
+            }
+            #[inline]
+            unsafe fn unchecked_add(self, other: Self) -> Self {
+                // SAFETY: Simply delegates
+                unsafe { <$target>::unchecked_add(self, other) }
+            }
+            #[inline]
+            unsafe fn unchecked_sub(self, other: Self) -> Self {
+                // SAFETY: Simply delegates
+                unsafe { <$target>::unchecked_sub(self, other) }
             }
             #[inline]
             fn from_usize_checked(val: usize) -> Option<Self> {

--- a/intid-core/src/utils.rs
+++ b/intid-core/src/utils.rs
@@ -1,5 +1,6 @@
 //! Miscellaneous utilities relating to the [`IntegerId`](crate::IntegerId) trait.
 
 mod order;
+mod iter;
 
 pub use self::order::OrderByInt;

--- a/intid-core/src/utils/iter.rs
+++ b/intid-core/src/utils/iter.rs
@@ -1,0 +1,82 @@
+use core::iter::StepBy;
+use core::num::NonZero;
+use crate::IntegerIdContiguous;
+
+pub fn contiguous<T: IntegerIdContiguous>() -> IterContiguous<T> {
+    IterContiguous {
+        next: T::MIN_ID_INT,
+    }
+}
+
+/// Indicates that the result of [`IterContiguous::len`] overflowed a [`u64`].
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub struct IterLengthOverflowError;
+
+pub struct IterContiguous<T: IntegerIdContiguous> {
+    /// The next value to be returned from the iterator.
+    ///
+    /// Invariants:
+    /// - When not `None`, `T::MIN_ID_INT <= next.to_int <= T::MAX_ID_INT`
+    next: Option<T>,
+}
+impl<T: IntegerIdContiguous> IterContiguous<T> {
+    pub fn len(&self) -> Result<u64, IterLengthOverflowError> {
+        match self.next {
+            None => Ok(0),
+            Some(current) => {
+                // Cannot overflow because Some(next) <= T::MAX_ID
+                //
+                // We can make this addition unchecked only if we trust the range
+                let delta = if T::TRUSTED_RANGE.is_some() {
+                    // SAFETY: We trust the range and our own invariants
+                    unsafe {
+                        crate::uint::unchecked_sub(
+                            T::MAX_ID_INT.unwrap(),
+                            current.to_int()
+                        )
+                    }
+                } else {
+                    T::MAX_ID_INT.unwrap() - current.to_int()
+                };
+                u64::try_from(delta).ok_or(IterLengthOverflowError)
+            }
+        }
+    }
+}
+
+impl<T: IntegerIdContiguous> core::iter::FusedIterator for IterContiguous<T> {}
+impl<T: IntegerIdContiguous> Iterator for IterContiguous<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        todo!()
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.next.unwrap().to_int();
+    }
+}
+impl<T: IntegerIdContiguous> ExactSizeIterator for IterContiguous<T> where T::Int: SmallerThanUsize {}
+
+/// Implemented for integer types smaller than a [`usize`].
+///
+/// Not implemented for `u32` on 64-bit platforms because that would be a portability hazard.
+/// It is implemented for `u16` on 32-bit/64-bit platforms,
+/// because supporting 16-bit platforms is rare in modern codebases.
+trait SmallerThanUsize {}
+#[cfg(not(target_pointer_width = "16"))]
+impl SmallerThanUsize for u16 {}
+impl SmallerThanUsize for u8 {}


### PR DESCRIPTION
Can only really implement `ExactSizeIterator` when the index is a `u8`. Maybe add some sort of `FitsIn<usize>` trait to work around this?

Could also piggyback on the `IntIegerdEnum` trait, adding the requirement the variant count fits in a usize.