### PR TITLE
Pin MSRV-compatible crate versions on old rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
         continue-on-error: false
+      - name: Pin MSRV-compatible versions
+        if: ${{ contains(matrix.rust, '1.') }}
+        env:
+          # this option is where the magic happens
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+        run: |
+          rm -f Cargo.lock
+          cargo +stable update
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-nextest


### PR DESCRIPTION
Handled automatically using the `resolver.incompatible-rust-versions` option, without needing to manually pin old versions.

Taking advantage of this option will make testing MSRV compatibility much easier across all my rust projects.