### PR TITLE
Add `EnumSet` type and restrict `EnumId` to 16-bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,11 @@ too-many-lines = "allow"
 must-use-candidate = "allow"
 return_self_not_must_use = "allow"
 items-after-statements = "allow"
+# these can actually make things clearer
+redundant-else = "allow"
+needless-continue = "allow"
+if-not-else = "allow"
+# done intentionally to make sure certian code type checks
+no-effect-underscore-binding = "allow"
+# too many false positives
+missing-panics-doc = "allow"

--- a/idmap/Cargo.toml
+++ b/idmap/Cargo.toml
@@ -39,6 +39,8 @@ serde_test = "1"
 serde_derive = "1"
 itertools = "0.14"
 intid-derive.workspace = true
+quickcheck = "1"
+thiserror = "2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/idmap/src/direct/macros.rs
+++ b/idmap/src/direct/macros.rs
@@ -84,7 +84,7 @@ macro_rules! impl_direct_set_iter {
                 self.len
             }
         }
-        impl<$($lt,)* T: IntegerId> DoubleEndedIterator for $target<$($lt,)* T> {
+        impl<$($lt,)* T: $key_bound> DoubleEndedIterator for $target<$($lt,)* T> {
             #[inline]
             fn next_back(&mut self) -> Option<Self::Item> {
                 match self.handle.next_back() {
@@ -100,8 +100,8 @@ macro_rules! impl_direct_set_iter {
                 }
             }
         }
-        impl<$($lt,)* T: IntegerId> ExactSizeIterator for $target<$($lt,)* T> {}
-        impl<$($lt,)* T: IntegerId> FusedIterator for $target<$($lt,)* T> {}
+        impl<$($lt,)* T: $key_bound> ExactSizeIterator for $target<$($lt,)* T> {}
+        impl<$($lt,)* T: $key_bound> FusedIterator for $target<$($lt,)* T> {}
     };
 }
 

--- a/idmap/src/direct/set.rs
+++ b/idmap/src/direct/set.rs
@@ -6,6 +6,7 @@
 //! [`HashSet`]: std::collections::HashMap
 //! [`DirectIdMap`]: crate::direct::DirectIdMap
 
+use crate::utils::bitsets::retain_word;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
@@ -156,26 +157,6 @@ impl<T: IntegerId> DirectIdSet<T> {
             self.len -= word_removed as usize;
         }
     }
-}
-/// The type of a word in a [`FixedBitSet`].
-type Word = fixedbitset::Block;
-#[inline]
-fn retain_word<F: FnMut(u32) -> bool>(original_word: Word, mut func: F) -> (Word, u32) {
-    let mut remaining = original_word;
-    let mut result = original_word;
-    let mut removed = 0;
-    while remaining != 0 {
-        let bit = remaining.trailing_zeros();
-        let mask: Word = 1 << bit;
-        debug_assert_ne!(result & mask, 0);
-        if !func(bit) {
-            result &= !mask;
-            removed += 1;
-        }
-        remaining &= !mask;
-    }
-    debug_assert!(removed <= 32);
-    (result, removed)
 }
 impl<T: IntegerId> Default for DirectIdSet<T> {
     #[inline]

--- a/idmap/src/enums.rs
+++ b/idmap/src/enums.rs
@@ -9,5 +9,54 @@
 pub mod map;
 #[cfg(feature = "serde")]
 mod serde;
+pub mod set;
+
+use intid::array::BitsetLimb;
+use intid::{uint, EnumId};
 
 pub use self::map::EnumMap;
+pub use self::set::EnumSet;
+
+pub(crate) struct VerifiedEnumInfo {
+    pub array_len: usize,
+    pub bitset_len: usize,
+}
+
+/// Verify the specified [`EnumId`] type sensibly implements
+/// [`EnumId::Array`], [`EnumId::BitSet`] and [`EnumId::COUNT`].
+///
+/// Needs to be passed a specific value type `V` to check the length of [`EnumId::Array`]
+///
+/// Unless this function ultimately panics,
+/// all of these checks will be constant-folded away.
+#[inline]
+#[track_caller]
+pub(crate) fn verify_enum_type<K: EnumId, V>() -> VerifiedEnumInfo {
+    let type_name = core::any::type_name::<K>();
+    let expected_array_len = u32::from(match K::MAX_ID_INT {
+        None => 0,
+        Some(max_id) => uint::checked_cast::<K::Int, u16>(max_id)
+            .and_then(|x| x.checked_add(1))
+            .unwrap_or_else(|| panic!("max_id for {type_name} overflows a u16")),
+    });
+    let actual_array_len = <K::Array<V> as intid::array::Array<V>>::LEN;
+    assert_eq!(
+        expected_array_len as u64, actual_array_len as u64,
+        "Unexpected array length for {type_name}"
+    );
+    assert!(
+        K::COUNT <= expected_array_len,
+        "Unexpected EnumId::COUNT = {count} > {expected_array_len} for {type_name}",
+        count = K::COUNT
+    );
+    let actual_bitset_len = <K::BitSet as intid::array::Array<BitsetLimb>>::LEN;
+    let expected_bitset_len = (expected_array_len + (BitsetLimb::BITS - 1)) / BitsetLimb::BITS;
+    assert_eq!(
+        actual_bitset_len as u64, expected_bitset_len as u64,
+        "Unexpected bitset length for {type_name} (array_len = {expected_array_len})"
+    );
+    VerifiedEnumInfo {
+        array_len: expected_array_len as usize,
+        bitset_len: expected_bitset_len as usize,
+    }
+}

--- a/idmap/src/enums/set.rs
+++ b/idmap/src/enums/set.rs
@@ -1,0 +1,399 @@
+//! Implements an [`EnumSet`] using a bitset.
+
+use crate::direct::macros::impl_direct_set_iter;
+use crate::utils::bitsets::ones::OnesIter;
+use crate::utils::bitsets::retain_word;
+use alloc::boxed::Box;
+use core::cmp::Ordering;
+use core::fmt;
+use core::fmt::{Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
+use core::ops::Index;
+use intid::array::{Array, BitsetLimb};
+use intid::{EnumId, EquivalentId};
+
+/// A set whose members implement [`EnumId`].
+///
+/// This is implemented as a bitset,
+/// so memory is proportional to [`EnumId::COUNT`].
+#[derive(Clone)]
+pub struct EnumSet<T: EnumId> {
+    limbs: T::BitSet,
+    /// It is possible to avoid storing this field by using a [popcount] instruction
+    /// like [`u64::count_ones`]
+    ///
+    /// On older architectures, popcount can be very slow.
+    /// Even on recent Intel architectures, the instruction has a 3-cycle latency.
+    /// We don't want the `len()` call to any slower than [`crate::DirectIdSet`],
+    /// so we unconditionally store the length even when [`T::COUNT`] is small.
+    ///
+    /// Intel AVX2 has instructions to accelerate popcount computation,
+    /// as discussed in [this paper] and implemented in [this library].
+    /// We could consider implementing this behind a cfg-flag
+    /// if the space savings become significant enough.
+    ///
+    /// It is safe to use a `u16` because `EnumId::MAX_ID + 1` is guaranteed to always fit in it.
+    /// This may change in the future.
+    ///
+    /// [popcount]: https://en.wikipedia.org/wiki/Hamming_weight
+    /// [this paper]: https://arxiv.org/pdf/1611.07a612
+    /// [this library]: https://github.com/kimwalisch/libpopcnt
+    len: u16,
+    marker: PhantomData<T>,
+}
+#[inline]
+fn divmod_index(index: u32) -> (usize, u32) {
+    (
+        (index / BitsetLimb::BITS) as usize,
+        index % BitsetLimb::BITS,
+    )
+}
+#[inline]
+fn bitmask_for(bit_index: u32) -> BitsetLimb {
+    let one: BitsetLimb = 1;
+    one << bit_index
+}
+impl<T: EnumId> EnumSet<T> {
+    /// Create a new set with no entries.
+    #[inline]
+    pub fn new() -> Self {
+        assert_eq!(
+            crate::enums::verify_enum_type::<T, ()>().bitset_len,
+            Self::BITSET_LEN
+        );
+        // We could just zero initialize the whole map
+        let _assert_can_zero_init = <Self as crate::utils::Zeroable>::zeroed;
+        // However, we initialize field-by-field in case that is somehow faster (skips padding?)
+        EnumSet {
+            // SAFETY: We know that that limbs is an array of integers, so can be zero-initialized
+            limbs: unsafe { core::mem::zeroed() },
+            len: 0,
+            marker: PhantomData,
+        }
+    }
+
+    const BITSET_LEN: usize = <T::BitSet as intid::array::Array<BitsetLimb>>::LEN;
+
+    /// Create a new set with no entries, allocating memory on the heap instead of the stack.
+    ///
+    /// Using `Box::new(EnumSet::new())` could require moving the underlying table
+    /// from the stack to the heap, as LLVM can struggle at eliminating copies.
+    /// This method avoids that copy by always allocating in-place.
+    #[inline]
+    pub fn new_boxed() -> Box<Self> {
+        assert_eq!(
+            crate::enums::verify_enum_type::<T, ()>().bitset_len,
+            Self::BITSET_LEN
+        );
+        crate::utils::Zeroable::zeroed_boxed()
+    }
+
+    #[inline]
+    fn limbs(&self) -> &[BitsetLimb] {
+        self.limbs.as_ref()
+    }
+
+    #[inline]
+    fn limbs_mut(&mut self) -> &mut [BitsetLimb] {
+        self.limbs.as_mut()
+    }
+
+    #[cold]
+    fn index_overflow() -> ! {
+        panic!(
+            "An index for `{}` overflowed its claimed maximum",
+            core::any::type_name::<T>()
+        )
+    }
+
+    /// Break apart a key into its word index and bit index.
+    ///
+    /// Guarantees that the resulting word index will be in-bounds for the bitset.
+    ///
+    /// # Safety
+    /// Relies on the unsafe guarantees of [`IntegerId::TRUSTED_RANGE`] if present.
+    /// If this token is missing, this function makes no unsafe assumptions.
+    #[inline]
+    fn verified_index(key: &T) -> (usize, u32) {
+        let index = intid::uint::checked_cast::<_, u32>(key.to_int()).unwrap_or_else(|| {
+            if T::TRUSTED_RANGE.is_some() {
+                // SAFETY: We have a TRUSTED_RANGE, so cannot overflow a u32
+                unsafe { core::hint::unreachable_unchecked() }
+            } else {
+                Self::index_overflow()
+            }
+        });
+        let (word_index, bit_index) = divmod_index(index);
+        // if we don't have a TRUSTED_RANGE, we have to do a length check
+        if T::TRUSTED_RANGE.is_none() && word_index >= Self::BITSET_LEN {
+            Self::index_overflow();
+        }
+        (word_index, bit_index)
+    }
+
+    /// Inserts the specified element into the set,
+    /// returning `true` if it was newly added and `false` if it was already present.
+    ///
+    /// Return value is consistent with [`HashSet::insert`].
+    ///
+    /// [`HashSet::insert`]: std::collections::HashSet::insert
+    #[inline]
+    pub fn insert(&mut self, value: T) -> bool {
+        let (word_index, bit_index) = Self::verified_index(&value);
+        // SAFETY: Validity of word index checked by verified_index
+        let word = unsafe { self.limbs_mut().get_unchecked_mut(word_index) };
+        let mask = bitmask_for(bit_index);
+        let was_present = (mask & *word) != 0;
+        *word |= mask;
+        !was_present
+    }
+
+    /// Remove the specified value from the set,
+    /// returning whether it was previously present.
+    ///
+    /// Return value is consistent with [`HashSet::remove`].
+    ///
+    /// [`HashSet::remove`]: std::collections::HashSet::insert
+    #[inline]
+    pub fn remove(&mut self, value: impl EquivalentId<T>) -> bool {
+        let value = value.as_id();
+        let (word_index, bit_index) = Self::verified_index(&value);
+        // SAFETY: Validity of word index checked by verified_index
+        let word = unsafe { self.limbs_mut().get_unchecked_mut(word_index) };
+        let mask = bitmask_for(bit_index);
+        let was_present = (mask & *word) != 0;
+        *word &= !mask;
+        was_present
+    }
+
+    /// Check if this set contains the specified value
+    #[inline]
+    pub fn contains(&self, value: impl EquivalentId<T>) -> bool {
+        let (word_index, bit_index) = Self::verified_index(&value.as_id());
+        // SAFETY: Validity of word index checked by verified_index
+        let word = unsafe { self.limbs().get_unchecked(word_index) };
+        (word & bitmask_for(bit_index)) != 0
+    }
+
+    /// Iterate over the values in this set.
+    ///
+    /// Guaranteed to be ordered by the integer value of the key.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            len: self.len as usize,
+            handle: OnesIter::new(self.limbs().iter().copied()),
+            marker: PhantomData,
+        }
+    }
+
+    /// Clear the values in this set
+    #[inline]
+    pub fn clear(&mut self) {
+        // SAFETY: Since the limbs are an array of integers,
+        // they are safe to zero initialize
+        unsafe {
+            core::ptr::write_bytes(&mut self.limbs, 0, 1);
+        }
+        self.len = 0;
+    }
+
+    /// The number of entries in this set
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// If this set is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Retain values in the set if the specified closure returns true
+    ///
+    /// Otherwise, they are removed
+    pub fn retain<F: FnMut(T) -> bool>(&mut self, mut func: F) {
+        for (word_index, word) in self.limbs.as_mut().iter_mut().enumerate() {
+            let (updated_word, word_removed) = retain_word(*word, |bit| {
+                let id = (word_index * 32) + (bit as usize);
+                // Safety: If present in the map, it is known to be valid
+                let key = unsafe { T::from_int_unchecked(intid::uint::from_usize_wrapping(id)) };
+                func(key)
+            });
+            *word = updated_word;
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                // bits will never exceed u16
+                self.len -= word_removed as u16;
+            }
+        }
+    }
+}
+// SAFETY: We know that the bitset can be zero-initialized because it is an array of integers
+// The only other field is the length, which can also be zero-initialized
+unsafe impl<T: EnumId> crate::utils::Zeroable for EnumSet<T> {}
+
+impl<T: EnumId> Default for EnumSet<T> {
+    #[inline]
+    fn default() -> Self {
+        EnumSet::new()
+    }
+}
+impl<T: EnumId> PartialEq for EnumSet<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.limbs() == other.limbs()
+    }
+}
+impl<T: EnumId> Eq for EnumSet<T> {}
+impl<T: EnumId> Debug for EnumSet<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+impl<T: EnumId> Extend<T> for EnumSet<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for value in iter {
+            self.insert(value);
+        }
+    }
+}
+impl<'a, T: EnumId> Extend<&'a T> for EnumSet<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().copied());
+    }
+}
+impl<T: EnumId> FromIterator<T> for EnumSet<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut set = Self::new();
+        set.extend(iter);
+        set
+    }
+}
+
+impl<'a, T: EnumId> FromIterator<&'a T> for EnumSet<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Self {
+        iter.into_iter().copied().collect()
+    }
+}
+
+impl<'a, T: EnumId + 'a> IntoIterator for &'a EnumSet<T> {
+    type Item = T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+impl<T: EnumId> IntoIterator for EnumSet<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            len: self.len as usize,
+            marker: PhantomData,
+            handle: OnesIter::new(Array::into_iter(self.limbs)),
+        }
+    }
+}
+
+impl<'a, T: EnumId + 'a> Index<&'a T> for EnumSet<T> {
+    type Output = bool;
+
+    #[inline]
+    fn index(&self, index: &'a T) -> &Self::Output {
+        &self[*index]
+    }
+}
+impl<T: EnumId> Index<T> for EnumSet<T> {
+    type Output = bool;
+
+    #[inline]
+    fn index(&self, index: T) -> &Self::Output {
+        const TRUE_REF: &bool = &true;
+        const FALSE_REF: &bool = &false;
+        if self.contains(index) {
+            TRUE_REF
+        } else {
+            FALSE_REF
+        }
+    }
+}
+impl<T: EnumId + Hash> Hash for EnumSet<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_usize(self.len());
+        // guaranteed to be ordered by key
+        for value in self {
+            value.hash(state);
+        }
+    }
+}
+impl<T: EnumId + PartialOrd> PartialOrd for EnumSet<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.iter().partial_cmp(other.iter())
+    }
+}
+impl<T: EnumId + Ord> Ord for EnumSet<T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iter().cmp(other.iter())
+    }
+}
+
+/// An iterator over the values in an [`EnumSet`].
+///
+/// [PR #130]: https://github.com/petgraph/fixedbitset/pull/130
+pub struct Iter<'a, T: EnumId> {
+    len: usize,
+    handle: OnesIter<BitsetLimb, core::iter::Copied<core::slice::Iter<'a, BitsetLimb>>>,
+    marker: PhantomData<fn() -> T>,
+}
+impl_direct_set_iter!(Iter<'a, K: EnumId>);
+
+/// An iterator over the values in an [`EnumSet`],
+/// consuming ownership the set.
+pub struct IntoIter<T: EnumId> {
+    handle: OnesIter<BitsetLimb, <T::BitSet as Array<BitsetLimb>>::Iter>,
+    len: usize,
+    marker: PhantomData<T>,
+}
+impl_direct_set_iter!(IntoIter<K: EnumId>);
+
+#[cfg(feature = "petgraph_0_8")]
+impl<T: EnumId> petgraph_0_8::visit::VisitMap<T> for EnumSet<T> {
+    #[inline]
+    fn visit(&mut self, a: T) -> bool {
+        self.insert(a)
+    }
+    #[inline]
+    fn is_visited(&self, value: &T) -> bool {
+        self.contains(*value)
+    }
+    #[inline]
+    fn unvisit(&mut self, a: T) -> bool {
+        self.remove(a)
+    }
+}
+
+/// Creates an [`EnumSet`] from a list of values
+#[macro_export]
+macro_rules! direct_enum_map {
+    () => ($crate::enums::EnumSet::new());
+    ($($value:expr),+ $(,)?) => ({
+        let mut set = $crate::enums::EnumSet::new();
+        $(set.insert($value);)*
+        set
+    });
+}

--- a/idmap/src/utils.rs
+++ b/idmap/src/utils.rs
@@ -2,26 +2,56 @@ use alloc::boxed::Box;
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
 
+pub mod bitsets;
+
+macro_rules! box_uninit_alloc_impl {
+    (for $tp:ident {
+        Box::new(MaybeUninit::$explicit_create:ident),
+        unsafe { Box::from_raw(std::alloc::$alloc_func:ident) }
+    }) => {{
+        let layout = Layout::new::<$tp>();
+        if layout.size() == 0 {
+            // this does not move any memory because `T` is a ZST
+            Box::new(MaybeUninit::$explicit_create())
+        } else {
+            // SAFETY: Not a zero sized type
+            let allocated = unsafe { alloc::alloc::alloc(layout) }.cast::<MaybeUninit<$tp>>();
+            if allocated.is_null() {
+                alloc::alloc::handle_alloc_error(layout)
+            } else {
+                // SAFETY: Allocated using the regular global allocator
+                // No need to initialize since the return type is `MaybeUninit`
+                unsafe { Box::from_raw(allocated) }
+            }
+        }
+    }};
+}
+
 /// A polyfill for [`Box::new_uninit`].
 ///
 /// Useful for allocating memory in-place without copying.
 #[inline]
 pub fn box_alloc_uninit<T>() -> Box<MaybeUninit<T>> {
-    let layout = Layout::new::<T>();
-    if layout.size() == 0 {
-        // this does not move any memory because `T` is a ZST
-        Box::new(MaybeUninit::uninit())
-    } else {
-        // SAFETY: Not a zero sized type
-        let allocated = unsafe { alloc::alloc::alloc(layout) }.cast::<MaybeUninit<T>>();
-        if allocated.is_null() {
-            alloc::alloc::handle_alloc_error(layout)
-        } else {
-            // SAFETY: Allocated using the regular global allocator
-            // No need to initialize since the return type is `MaybeUninit`
-            unsafe { Box::from_raw(allocated) }
-        }
-    }
+    box_uninit_alloc_impl!(for T {
+        Box::new(MaybeUninit::uninit),
+        // SAFETY: Allocated using the global allocator.
+        // Since the return type is `MaybeUninit`, the contents don't matter
+        unsafe { Box::from_raw(std::alloc::alloc) }
+    })
+}
+
+/// A polyfill for [`Box::new_zeroed`].
+///
+/// Useful for allocating memory in-place without copying.
+#[inline]
+pub fn box_alloc_zeroed<T>() -> Box<MaybeUninit<T>> {
+    box_uninit_alloc_impl!(for T {
+        Box::new(MaybeUninit::uninit),
+        // SAFETY: Allocated using the global allocator.
+        // Since the return type is `MaybeUninit`,
+        // the zero-initialization of the contents doesn't matter
+        unsafe { Box::from_raw(std::alloc::alloc_zeroed) }
+    })
 }
 
 /// A polyfill for [`Box<MaybeUninit<T>>::assume_init`].
@@ -33,4 +63,29 @@ pub unsafe fn box_assume_init<T>(value: Box<MaybeUninit<T>>) -> Box<T> {
     let ptr: *mut MaybeUninit<T> = Box::into_raw(value);
     // SAFETY: Initialization is guaranteed by the caller
     unsafe { Box::from_raw(ptr.cast::<T>()) }
+}
+
+/// Indicates that a type can be zero-initialized.
+///
+/// This is equivalent to the [`bytemuck::Zeroable`] trait,
+/// but is an implementation detail that is not exposed publicly.
+///
+/// [`bytemuck::Zeroable`]: https://docs.rs/bytemuck/1/bytemuck/trait.Zeroable.html
+///
+/// # Safety
+/// The type must be valid to initialize with zeroes.
+///
+/// Must not override any of the inherent methods.
+pub(crate) unsafe trait Zeroable: Sized {
+    #[inline]
+    fn zeroed_boxed() -> Box<Self> {
+        let zeroed = box_alloc_zeroed();
+        // SAFETY: Implementation of the trait means that Self can be zero initialized
+        unsafe { box_assume_init(zeroed) }
+    }
+    #[inline]
+    fn zeroed() -> Self {
+        // SAFETY: We know that this type can be zero initialized
+        unsafe { core::mem::zeroed() }
+    }
 }

--- a/idmap/src/utils/bitsets.rs
+++ b/idmap/src/utils/bitsets.rs
@@ -1,0 +1,40 @@
+//! Utilities for bitsets typesl.
+use core::ops::{BitAnd, BitAndAssign, Not, Shl};
+use intid::uint::{one, trailing_zeros, zero};
+use intid::UnsignedPrimInt;
+
+pub trait BitsetWord:
+    UnsignedPrimInt
+    + Shl<u32, Output = Self>
+    + BitAnd<Output = Self>
+    + BitAndAssign
+    + Not<Output = Self>
+{
+}
+impl BitsetWord for u32 {}
+impl BitsetWord for usize {}
+impl BitsetWord for u64 {}
+
+pub mod ones;
+
+#[inline]
+pub fn retain_word<W: BitsetWord, F: FnMut(u32) -> bool>(
+    original_word: W,
+    mut func: F,
+) -> (W, u32) {
+    let mut remaining = original_word;
+    let mut result = original_word;
+    let mut removed = 0;
+    while remaining != zero() {
+        let bit = trailing_zeros(remaining);
+        let mask: W = one::<W>() << bit;
+        debug_assert_ne!(result & mask, zero());
+        if !func(bit) {
+            result &= !mask;
+            removed += 1;
+        }
+        remaining &= !mask;
+    }
+    debug_assert!(removed <= 32);
+    (result, removed)
+}

--- a/idmap/src/utils/bitsets/ones.rs
+++ b/idmap/src/utils/bitsets/ones.rs
@@ -1,0 +1,281 @@
+use crate::utils::bitsets::BitsetWord;
+use intid::uint::{bits, count_ones, leading_zeros, one, trailing_zeros, zero};
+
+/// Iterate over the ones in a single word.
+#[derive(Clone)]
+pub struct SingleWordOnes<W: BitsetWord> {
+    word: W,
+}
+impl<W: BitsetWord> SingleWordOnes<W> {
+    #[inline]
+    pub fn new(word: W) -> SingleWordOnes<W> {
+        Self { word }
+    }
+}
+impl<W: BitsetWord> Iterator for SingleWordOnes<W> {
+    type Item = u32;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.word != W::ZERO {
+            let first_one = trailing_zeros(self.word);
+            let mask: W = one::<W>() << first_one;
+            debug_assert_ne!(self.word & mask, zero());
+            self.word &= !mask;
+            Some(first_one)
+        } else {
+            None
+        }
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = count_ones(self.word) as usize;
+        (len, Some(len))
+    }
+}
+impl<W: BitsetWord> ExactSizeIterator for SingleWordOnes<W> {}
+impl<W: BitsetWord> DoubleEndedIterator for SingleWordOnes<W> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.word != zero() {
+            let last_one = (bits::<W>() - leading_zeros(self.word)) - 1;
+            let mask: W = one::<W>() << last_one;
+            debug_assert_ne!(self.word & mask, zero());
+            self.word &= !mask;
+            Some(last_one)
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterate over all the ones in a bitset,
+/// given an iterator over the words.
+#[derive(Clone)]
+pub struct OnesIter<W: BitsetWord, I: Iterator<Item = W>> {
+    /// The word at the beginning of the iterator.
+    ///
+    /// This is used by [`Self::next`] before getting a new word from the `word_iter`.
+    begin_word: Option<(usize, SingleWordOnes<W>)>,
+    /// The word at the beginning of the iterator.
+    ///
+    /// This is used by [`Self::next_back`] before getting a new word from the `word_iter`.
+    ///
+    /// It will be `None` if [`Self::next_back`] is never used.
+    end_word: Option<(usize, SingleWordOnes<W>)>,
+    word_iter: core::iter::Enumerate<I>,
+}
+impl<W: BitsetWord, I: Iterator<Item = W>> OnesIter<W, I> {
+    #[inline]
+    fn combined_index(word_index: usize, bit_index: u32) -> usize {
+        // This could be unchecked math if we really trusted the source iterator length
+        (word_index * bits::<W>() as usize) + (bit_index as usize)
+    }
+}
+macro_rules! word_actions {
+    ($(fn $name:ident { $target_var:ident, $action:ident })+) => {
+        $(#[inline]
+        fn $name(&mut self) -> Option<usize> {
+            #[allow(clippy::question_mark)] // applying suggestion would require as_mut()
+            let Some((word_index, ref mut word_iter)) = self.$target_var else {
+                return None;
+            };
+            let bit_index = word_iter.$action()?;
+            Some(Self::combined_index(word_index, bit_index))
+        })*
+    };
+}
+impl<W: BitsetWord, I: Iterator<Item = W>> OnesIter<W, I> {
+    #[inline]
+    pub fn new(word: I) -> Self {
+        OnesIter {
+            begin_word: None,
+            end_word: None,
+            word_iter: word.enumerate(),
+        }
+    }
+    word_actions!(fn next_from_beginning { begin_word, next });
+    word_actions!(fn next_from_ending { end_word, next });
+    word_actions!(fn next_back_from_beginning { begin_word, next_back });
+    word_actions!(fn next_back_from_ending { end_word, next_back });
+}
+impl<W: BitsetWord, I: Iterator<Item = W>> Iterator for OnesIter<W, I> {
+    type Item = usize;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(combined_index) = self.next_from_beginning() {
+                return Some(combined_index);
+            } else if let Some((next_word_index, next_word)) = self.word_iter.next() {
+                self.begin_word = Some((next_word_index, SingleWordOnes::new(next_word)));
+                continue;
+            } else if let Some(combined_index) = self.next_from_ending() {
+                return Some(combined_index);
+            } else {
+                return None;
+            }
+        }
+    }
+    #[cfg(any())] // untested
+    fn fold<B, F>(mut self, init: B, mut func: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut result = init;
+        while let Some(bit_index) = self.next_from_beginning() {
+            result = func(result, bit_index);
+        }
+        for (word_index, word) in self.word_iter.by_ref() {
+            for bit_index in SingleWordOnes::new(word) {
+                result = func(result, Self::combined_index(word_index, bit_index));
+            }
+        }
+        while let Some(bit_index) = self.next_from_ending() {
+            result = func(result, bit_index);
+        }
+        result
+    }
+}
+
+impl<W: BitsetWord, I: DoubleEndedIterator<Item = W> + ExactSizeIterator> DoubleEndedIterator
+    for OnesIter<W, I>
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(combined_index) = self.next_back_from_ending() {
+                return Some(combined_index);
+            } else if let Some((next_word_index, next_word)) = self.word_iter.next_back() {
+                self.end_word = Some((next_word_index, SingleWordOnes::new(next_word)));
+                continue;
+            } else if let Some(combined_index) = self.next_back_from_beginning() {
+                return Some(combined_index);
+            } else {
+                return None;
+            }
+        }
+    }
+    #[cfg(any())] // untested
+    fn rfold<B, F>(mut self, init: B, mut func: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut result = init;
+        while let Some(bit_index) = self.next_back_from_ending() {
+            result = func(result, bit_index);
+        }
+        for (word_index, word) in self.word_iter.by_ref().rev() {
+            for bit_index in SingleWordOnes::new(word) {
+                result = func(result, Self::combined_index(word_index, bit_index));
+            }
+        }
+        while let Some(bit_index) = self.next_back_from_beginning() {
+            result = func(result, bit_index);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OnesIter, SingleWordOnes};
+    use alloc::vec::Vec;
+    use fixedbitset::FixedBitSet;
+    use itertools::Itertools;
+    use quickcheck::QuickCheck;
+
+    #[derive(Debug, thiserror::Error)]
+    enum UnexpectedWords {
+        #[error("forward iteration failed, expected {expected:?} and got {actual:?}")]
+        ForwardIteration {
+            expected: Vec<usize>,
+            actual: Vec<usize>,
+        },
+        #[error("reverse iteration failed, expected {expected:?} and got {actual:?}")]
+        ReverseIteration {
+            expected: Vec<usize>,
+            actual: Vec<usize>,
+        },
+    }
+
+    fn check_iter<I>(target_iter: I, expected: &[usize]) -> Result<(), UnexpectedWords>
+    where
+        I: DoubleEndedIterator<Item = Word> + Clone,
+    {
+        let forward = target_iter.clone().collect::<Vec<_>>();
+        if forward != expected {
+            return Err(UnexpectedWords::ForwardIteration {
+                expected: expected.to_vec(),
+                actual: forward,
+            });
+        }
+        let reverse = target_iter.rev().collect::<Vec<_>>();
+        let expected_reverse = expected.iter().rev().copied().collect::<Vec<_>>();
+        if reverse != expected_reverse {
+            return Err(UnexpectedWords::ReverseIteration {
+                expected: expected_reverse,
+                actual: reverse,
+            });
+        }
+        Ok(())
+    }
+
+    const EXPECTED_77: &[usize] = &[0, 2, 3, 6];
+    const EXPECTED_102: &[usize] = &[1, 2, 5, 6];
+
+    #[test]
+    fn single_word() {
+        fn check_single(word: Word, expected: &[usize]) -> Result<(), UnexpectedWords> {
+            fn expand(x: u32) -> usize {
+                x as usize
+            }
+            check_iter(SingleWordOnes::new(word).map(expand), expected)
+        }
+        check_single(77, EXPECTED_77).unwrap();
+        check_single(102, EXPECTED_102).unwrap();
+        fn do_check(word: Word) -> Result<(), UnexpectedWords> {
+            check_single(
+                word,
+                &fixedbitset_from_words([word]).into_ones().collect_vec(),
+            )
+        }
+        QuickCheck::new().quickcheck(do_check as fn(_) -> _);
+    }
+    type Word = fixedbitset::Block;
+    fn fixedbitset_from_words<I: IntoIterator<Item = Word>>(words: I) -> FixedBitSet
+    where
+        I::IntoIter: ExactSizeIterator,
+    {
+        let words = words.into_iter();
+        FixedBitSet::with_capacity_and_blocks(words.len() * (Word::BITS as usize), words)
+    }
+
+    #[test]
+    fn multiple_words() {
+        fn offset_all(src: &[usize], by: usize) -> impl Iterator<Item = usize> + '_ {
+            src.iter().copied().map(move |val| val + by)
+        }
+        fn check_multiple(words: &[Word], expected: &[usize]) -> Result<(), UnexpectedWords> {
+            check_iter(OnesIter::new(words.iter().copied()), expected)
+        }
+        check_multiple(
+            &[77, 102, 77],
+            &itertools::chain!(
+                EXPECTED_77.iter().copied(),
+                offset_all(EXPECTED_102, Word::BITS as usize),
+                offset_all(EXPECTED_77, (Word::BITS as usize) * 2),
+            )
+            .collect_vec(),
+        )
+        .unwrap();
+        fn do_check(words: Vec<Word>) -> Result<(), UnexpectedWords> {
+            check_multiple(
+                &words,
+                &fixedbitset_from_words(words.iter().copied())
+                    .into_ones()
+                    .collect_vec(),
+            )
+        }
+        QuickCheck::new().quickcheck(do_check as fn(_) -> _);
+    }
+}

--- a/idmap/tests/enum_set.rs
+++ b/idmap/tests/enum_set.rs
@@ -1,0 +1,189 @@
+#![allow(missing_docs)]
+#![allow(clippy::bool_assert_comparison)] // clearer
+use intid_derive::IntegerId;
+use itertools::Itertools;
+use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_test::{assert_tokens, Token};
+
+use idmap::direct::set::DirectIdSet as IdSet;
+use idmap::direct_idset as idset;
+use KnownState::*;
+
+#[test]
+fn remove() {
+    let mut m = important_states();
+    assert_eq!(m.remove(NewMexico), false);
+    for state in IMPORTANT_STATES {
+        assert_eq!(m.remove(state), true);
+    }
+    assert_eq!(m.len(), 0);
+    assert_eq!(m.remove(NewMexico), false);
+    assert_eq!(m.remove(NorthDakota), false);
+}
+
+#[test]
+fn eq() {
+    let first = important_states();
+    let mut second = important_states().iter().collect_vec();
+    second.reverse();
+    let second = second.iter().collect::<IdSet<_>>();
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn from_iter() {
+    let xs = [California, NewYork, Arizona];
+
+    let set: IdSet<_> = xs.iter().copied().collect();
+
+    for state in &xs {
+        assert_eq!(set[state], true);
+    }
+    check_missing(TINY_STATES, &set);
+}
+
+#[test]
+fn clone() {
+    let original = important_states();
+    let cloned = original.clone();
+    assert_eq!(original, cloned);
+}
+
+#[test]
+fn index() {
+    let set = important_states();
+
+    for state in IMPORTANT_STATES {
+        assert_eq!(set[state], true);
+    }
+    assert_eq!(set[NorthDakota], false);
+}
+
+#[test]
+fn entry_insert() {
+    let mut set = important_states();
+
+    for &state in ALL_STATES {
+        set.insert(state);
+    }
+    check_cities(ALL_STATES, &set);
+}
+
+#[test]
+fn extend_ref() {
+    let important = important_states();
+    let mut all = IdSet::new();
+    all.insert(NewMexico);
+    all.insert(California);
+    all.insert(NorthDakota);
+
+    all.extend(&important);
+
+    assert_eq!(all.len(), 5);
+    // Updates must remain in declaration order
+    assert_eq!(all.iter().nth(1).unwrap(), California);
+    assert_eq!(all.iter().nth(4).unwrap(), NorthDakota);
+    check_cities(ALL_STATES, &all);
+}
+
+#[test]
+fn retain() {
+    let mut set = important_states();
+    set.retain(|state| match state {
+        NewYork => false, // New york city is too big!
+        California | Arizona => true,
+        _ => unreachable!(),
+    });
+    assert_eq!(set.len(), 2);
+    check_cities(&[Arizona, California], &set);
+    check_missing(TINY_STATES, &set);
+}
+
+/// List the biggest cities in each state except for `NewMexico` and `NorthDakota`,
+/// intentionally excluding them to provide a better test case.
+fn important_states() -> IdSet<KnownState> {
+    idset!(Arizona, NewYork, California)
+}
+#[derive(IntegerId, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Ord, PartialOrd, Eq)]
+enum KnownState {
+    Arizona,
+    California,
+    NewMexico,
+    NewYork,
+    NorthDakota,
+}
+fn check_missing(states: &[KnownState], target: &IdSet<KnownState>) {
+    for state in states {
+        assert_eq!(target[state], false);
+    }
+}
+fn check_cities(states: &[KnownState], target: &IdSet<KnownState>) {
+    for state in states {
+        assert_eq!(target[state], true);
+    }
+}
+static ALL_STATES: &[KnownState] = &[Arizona, California, NewMexico, NewYork, NorthDakota];
+// NOTE: Intentionally out of declared order to try and mess things up
+
+static IMPORTANT_STATES: &[KnownState] = &[Arizona, NewYork, California];
+static TINY_STATES: &[KnownState] = &[NorthDakota, NewMexico];
+
+#[test]
+fn wrapper() {
+    let data = idset!(ExampleWrapper(32), ExampleWrapper(42));
+    assert_eq!(data[ExampleWrapper(32)], true);
+    assert_eq!(data[ExampleWrapper(42)], true);
+    assert_eq!(data[ExampleWrapper(76)], false);
+}
+
+#[test]
+fn struct_wrapper() {
+    let data = idset!(ExampleStructWrapper::new(32), ExampleStructWrapper::new(42));
+    assert_eq!(data[ExampleStructWrapper::new(32)], true);
+    assert_eq!(data[ExampleStructWrapper::new(42)], true);
+    assert_eq!(data[ExampleStructWrapper::new(76)], false);
+}
+
+#[test]
+fn insert_expand() {
+    let mut data = idset!(0u32);
+    assert!(!data.insert(0));
+    assert!(data.insert(15));
+    assert!(data.insert(512));
+    assert!(!data.insert(15));
+    assert!(!data.insert(512));
+}
+
+#[derive(IntegerId, Copy, Clone, Eq, Debug, PartialEq)]
+struct ExampleWrapper(u16);
+#[derive(IntegerId, Copy, Clone, Eq, Debug, PartialEq)]
+struct ExampleStructWrapper {
+    value: u16,
+}
+impl ExampleStructWrapper {
+    #[inline]
+    fn new(value: u16) -> Self {
+        ExampleStructWrapper { value }
+    }
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn serde() {
+    macro_rules! state_tokens {
+        ($len:expr, $($state:ident),*) => (&[
+            Token::Seq { len: Some($len) },
+            $(
+                Token::Enum { name: "KnownState" },
+                Token::Str(stringify!($state)),
+                Token::Unit,
+            )*
+            Token::SeqEnd
+        ]);
+    }
+    // Remember, IdSet serializes in _declaration order_
+    const EXPECTED_TOKENS: &[Token] = state_tokens!(3, Arizona, California, NewYork);
+    assert_tokens(&important_states(), EXPECTED_TOKENS);
+}

--- a/intid-core/src/lib.rs
+++ b/intid-core/src/lib.rs
@@ -108,10 +108,20 @@ pub trait IntegerId: Copy + Eq + Debug + Send + Sync + 'static {
     /// This is necessary because trait methods cannot be marked `const`.
     const MAX_ID_INT: Option<Self::Int>;
 
-    /// Indicates that the type's implementation of [`IntegerId::to_int`] can trusted
+    /// Indicates that the type's implementation of [`IntegerId::to_int`] can be trusted
     /// to only return values in the range `MIN_ID_INT..=MAX_ID_INT`.
     ///
-    /// This can be relied upon by unsafe code, since the token is `unsafe` to construct.
+    /// Creating this token means that all of these guarantees can be relied upon for memory safety.
+    /// This allows unsafe code to avoid bounds checks,
+    /// but turns a correctness invariant into a soundness invariant.
+    ///
+    /// # Safety
+    /// The result of [`Self::to_int`] must always fall in the range `MIN_ID_INT..=MAX_ID_INT`.
+    ///
+    /// If [`EnumId`] is implemented,
+    /// then the requirements of the [`EnumId`] trait must be met as well.
+    /// In particular, the index must always fit in a `u32`
+    /// and have the appropriately `Array` and `BitSet` items.
     const TRUSTED_RANGE: Option<trusted::TrustedRangeToken<Self>> = None;
 
     /// Create an id from the underlying integer value,

--- a/intid-core/src/lib.rs
+++ b/intid-core/src/lib.rs
@@ -224,13 +224,20 @@ pub trait IntegerIdCounter: IntegerId + IntegerIdContiguous {
 /// Is not implemented for types like `u32` where inline storage
 /// would require inordinate amounts of space.
 ///
-/// All valid indexes and the total [`Self::COUNT`] must fit in a [`u32`] and a [`usize`].
+/// All valid indexes and [`Self::MAX_ID_INT + 1`](IntegerId::MAX_ID_INT)
+/// must fit into both a [`u16`] and a [`usize`].
+/// This means that [`u16`] cannot itself implement `EnumId`,
+/// since `u16::MAX + 1` doesn't fit in a [`u16`].
+/// Future versions of this trait may expand this to allow [`u32`] indexes,
+/// but that will be considered a breaking change for semver purposes.
 ///
 /// Note that this does *not* imply [`IntegerIdContiguous`],
 /// so not all be integers below [`Self::MAX_ID_INT`](IntegerId::MAX_ID_INT)
 /// are guaranteed to be valid.
 pub trait EnumId: IntegerId {
     /// The total number of valid values.
+    ///
+    /// This value must fit in a [`u16`].
     const COUNT: u32;
     /// A builtin array of `[T; {Self::MAX_ID_INT + 1}]`.
     ///

--- a/intid-core/src/uint.rs
+++ b/intid-core/src/uint.rs
@@ -128,6 +128,36 @@ pub const fn max_value<T: UnsignedPrimInt>() -> T {
     T::MAX
 }
 
+/// Determine the number of bits needed to represent the specified [`UnsignedPrimInt`].
+#[inline]
+pub const fn bits<T: UnsignedPrimInt>() -> u32 {
+    T::BITS
+}
+
+/// Get the number of trailing zeroes for the specified integer.
+///
+/// See [`u64::trailing_zeros`] for details.
+#[inline]
+pub fn trailing_zeros<T: UnsignedPrimInt>(val: T) -> u32 {
+    sealed::PrivateUnsignedInt::trailing_zeros(val)
+}
+
+/// Get the number of leading zeroes for the specified integer.
+///
+/// See [`u64::leading_zeros`] for details.
+#[inline]
+pub fn leading_zeros<T: UnsignedPrimInt>(val: T) -> u32 {
+    sealed::PrivateUnsignedInt::leading_zeros(val)
+}
+
+/// Count the number of one bits in the specified integer.
+///
+/// See [`u64::count_ones`] for details.
+#[inline]
+pub fn count_ones<T: UnsignedPrimInt>(val: T) -> u32 {
+    sealed::PrivateUnsignedInt::count_ones(val)
+}
+
 /// Attempt to describe the specified [`UnsignedPrimInt`]
 /// in a format suitable for debugging or panic messages.
 ///

--- a/intid-core/src/uint.rs
+++ b/intid-core/src/uint.rs
@@ -62,7 +62,7 @@ pub trait UnsignedPrimInt:
 /// Cast from one [`UnsignedPrimInt`] into another,
 /// returning `None` if there is overflow.
 #[inline]
-pub fn checked_cast<T: UnsignedPrimInt, U>(value: T) -> Option<T> {
+pub fn checked_cast<T: UnsignedPrimInt, U: UnsignedPrimInt>(value: T) -> Option<U> {
     sealed::PrivateUnsignedInt::checked_cast(value)
 }
 

--- a/intid-core/src/uint/sealed.rs
+++ b/intid-core/src/uint/sealed.rs
@@ -1,4 +1,5 @@
 pub trait PrivateUnsignedInt: Sized {
+    const BITS: u32;
     const ZERO: Self;
     const ONE: Self;
     const MAX: Self;
@@ -7,6 +8,9 @@ pub trait PrivateUnsignedInt: Sized {
     const TYPE_NAME: &'static str;
     fn checked_add(self, other: Self) -> Option<Self>;
     fn checked_sub(self, other: Self) -> Option<Self>;
+    fn trailing_zeros(self) -> u32;
+    fn leading_zeros(self) -> u32;
+    fn count_ones(self) -> u32;
     fn from_usize_checked(val: usize) -> Option<Self>;
     fn from_usize_wrapping(val: usize) -> Self;
     #[allow(clippy::wrong_self_convention)]
@@ -18,12 +22,14 @@ macro_rules! impl_primint {
     ($($target:ident),*) => ($(
         impl super::UnsignedPrimInt for $target {}
         impl super::ConvertPrimInts for $target {}
+        #[deny(unconditional_recursion)]
         impl PrivateUnsignedInt for $target {
             const TYPE_NAME: &'static str = stringify!($target);
             const ZERO: Self = {
                 assert!($target::MIN == 0, "signed integer");
                 0
             };
+            const BITS: u32 = $target::BITS;
             const ONE: Self = 1;
             const MAX: Self = $target::MAX;
             #[inline]
@@ -37,6 +43,18 @@ macro_rules! impl_primint {
             #[inline]
             fn checked_sub(self, other: Self) -> Option<Self> {
                 <$target>::checked_sub(self, other)
+            }
+            #[inline]
+            fn count_ones(self) -> u32 {
+                <$target>::count_ones(self)
+            }
+            #[inline]
+            fn leading_zeros(self) -> u32 {
+                <$target>::leading_zeros(self)
+            }
+            #[inline]
+            fn trailing_zeros(self) -> u32 {
+                <$target>::trailing_zeros(self)
             }
             #[inline]
             fn from_usize_checked(val: usize) -> Option<Self> {


### PR DESCRIPTION
Needs a bunch of additional code to implement the bitset. Changes and fixes some other code

The only breaking change is that `EnumId` is now required to fit in a `u16`. I am fine with releasing this in a patch-version, as using an EnumMap/EnumSet with more than `2^16` elements was already a terrible idea.